### PR TITLE
Reproduce senecajs/seneca#583

### DIFF
--- a/583/client.js
+++ b/583/client.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const seneca = require('seneca')();
+
+seneca.client({
+  type: 'http',
+  port: 12345,
+  host: '0.0.0.0',
+  pin: 'role:foo'
+});
+
+let name = 0;
+
+setInterval(() => {
+  seneca.act({
+    role: 'foo',
+    cmd: 'bar',
+    name: name++,
+  }, function (err, res) {
+    console.log(Date.now(), err, res);
+  });
+}, 1500);

--- a/583/package.json
+++ b/583/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "583",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "seneca": "^3.4.1"
+  }
+}

--- a/583/server.js
+++ b/583/server.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const seneca = require('seneca')();
+
+seneca.add({
+  role: 'foo',
+  cmd: 'bar'
+}, (args, cb) => {
+  console.log('Received request', args.id$);
+
+  setTimeout(() => {
+    console.log('Responding to request', args.id$);
+
+    cb(null, { name: args.name });
+  }, 2000); // Notice this is higher than the interval in the client
+})
+
+seneca.listen({
+  type: 'http',
+  port: 12345,
+  host: '0.0.0.0'
+});
+
+process.once('SIGINT', () => {
+  console.log('Received SIGINT');
+
+  // The server will keep listening and serving requests. The callback will be
+  // called once the client stops.
+  seneca.close(() => {
+    console.log('Seneca closed');
+  });
+});


### PR DESCRIPTION
Reproduces senecajs/seneca#583. Once the server receives SIGINT, it will continue to serve new requests even after calling `close`. The expected behavior is for the server to stop accepting new requests, finish the ongoing ones and finally call the callback.

```
$ node server.js
{"kind":"notice","notice":"hello seneca 9lofi6e4iqav/1500386136959/27325/3.4.1/-","level":"info","seneca":"9lofi6e4iqav/1500386136959/27325/3.4.1/-","when":1500386137118}
Received request 23fcqlpv0lo9/ryxs6li41vtz
Received request 75byax82e1uh/gjeeeqmjiw04
Responding to request 23fcqlpv0lo9/ryxs6li41vtz
Received request b1w0qacj7te2/tg77x8nhviaq
Responding to request 75byax82e1uh/gjeeeqmjiw04
Received request fmqy2fau7pno/hfyk23xyu8bb
Responding to request b1w0qacj7te2/tg77x8nhviaq
^CReceived SIGINT                                             <<<< ctrl+c
Received request x8ni0ytho6rk/yaq9rq3kas9k
Responding to request fmqy2fau7pno/hfyk23xyu8bb
Received request s0iagxt4dtvj/3j7de41zkvlb
Responding to request x8ni0ytho6rk/yaq9rq3kas9k
Received request bxkh0w07658v/emkkflbha6v2
Responding to request s0iagxt4dtvj/3j7de41zkvlb
Received request 2v7u5jgqapui/t4g78810nbzy
Responding to request bxkh0w07658v/emkkflbha6v2
Received request q5g8pxn0c6s4/5qjqxozkmzi2
Responding to request 2v7u5jgqapui/t4g78810nbzy
Responding to request q5g8pxn0c6s4/5qjqxozkmzi2
Seneca closed                                                 <<<< client killed
```